### PR TITLE
Do not expose full path in error message

### DIFF
--- a/core/model/modx/modmanagercontrollerdeprecated.class.php
+++ b/core/model/modx/modmanagercontrollerdeprecated.class.php
@@ -55,7 +55,7 @@ class modManagerControllerDeprecated extends modManagerController {
 
             $cbody = include $f;
         } else {
-            $cbody = 'Could not find action file at: '.$f;
+            $cbody = 'Could not find action file';
         }
 
         if (!empty($this->ruleOutput)) {


### PR DESCRIPTION
### What does it do?
This commit removes the full path from an on-page error message in Manager.

### Why is it needed?
If you modify the url parameters when in Manager, you can currently produce an error message that exposes the full path of the application (eg 'Could not find action file at: /home/webuser/public_html/manager/controllers/default/system/settings0.php').  Whilst this is low risk as it only applies to already authenticated users, it would be preferable if the full path was not shown on the page, but only in the error log which is only visible to users with appropriate permissions.  

### Related issue(s)/PR(s)
None
